### PR TITLE
Log refresh errors instead of attempts

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,13 +176,15 @@ LogitechHarmonyPlatform.prototype = {
       setTimeout(function() {
         setInterval(function() {
           executeOnHub(function(h, cb) {
-            plat.log("Refresh Status");
             h.getCurrentActivity()
                 .then(function(currentActivity){
                   cb();
                   updateCurrentActivity(currentActivity);
                 })
-                .catch(cb);
+                .catch(function (error) {
+                    plat.log("Error refreshing status: " + error);
+                    cb(error)
+                });
           });
         }, 20000);
       }, 5000);


### PR DESCRIPTION
This PR removes the refresh log message and instead only displays a log message when there's a problem refreshing. This keeps the plugin from cluttering homebridge output.