### PR TITLE
fix harmonyhubjs-discover semrel issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "harmonyhubjs-client": "^1.1.6",
-    "harmonyhubjs-discover": "git+https://github.com/swissmanu/harmonyhubjs-discover.git",
+    "harmonyhubjs-discover": "^1.0.2",
     "inherits": "^2.0.1",
     "node-stringprep": "^0.7.2",
     "node-xmpp-client": "1.0.0-alpha23",


### PR DESCRIPTION
@swissmanu introduced semantic-release for their harmonyhubjs-* projects, therefore removing the version field from the respective package.jsons, breaking installation as a dependency of this plugin.

this pull request changes this plugin's dependency on harmonyhubjs-discover to be retrieved not from git-repo but from npmjs release.