### PR TITLE
Trigger activity switching only if current state changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ Fields:
 
 * "platform": Must always be "HarmonyHub" (required)
 * "name": Can be anything (used in logs)
+* "skipIfSameState": Can be true or false. If true homebridge will not turn on/off activities if they already are in the desired state (optional, defaults to false)

--- a/lib/accessory-base.js
+++ b/lib/accessory-base.js
@@ -18,8 +18,9 @@ module.exports = function(exportedTypes) {
 };
 module.exports.AccessoryBase = AccessoryBase;
 
-function AccessoryBase(accessory, idKey, name, log) {
+function AccessoryBase(accessory, idKey, name, config, log) {
 	this.log = log;
+	this.config = config;
 
 	if (!accessory) {
 		var id = uuid.generate(idKey);

--- a/lib/activity-accessory.js
+++ b/lib/activity-accessory.js
@@ -192,19 +192,27 @@ ActivityAccessory.prototype._setActivityServiceOn = function(service, isOn, call
 		self.log.debug("Preemptively marking finished.");
 		finish();
 	};
-	return this.connection
-		.invokeAsync(function(client) {
-			self.log.debug("Switching to Activity: " + actId);
-			c.addListener('change', onChange);
 
-			var task = client.startActivity(actId);
-			self.log.debug("Switching Task Started: " + actId);
-			return task;
-		})
-		.asCallback(finish)
-		.finally(function(){
-			self.log.debug("Switch Task Finished: " + actId);
-		});
+	if ((isOn && !c.value) || (!isOn && c.value)) {
+		return this.connection
+			.invokeAsync(function(client) {
+				self.log.debug("Switching to Activity: " + actId);
+				c.addListener('change', onChange);
+
+				var task = client.startActivity(actId);
+				self.log.debug("Switching Task Started: " + actId);
+				return task;
+			})
+			.asCallback(finish)
+			.finally(function(){
+				self.log.debug("Switch Task Finished: " + actId);
+			});
+	} else {
+		var cb = callback;
+		callback = null;
+		c.removeListener('change', onChange);
+		if (cb) cb.apply(this, []);
+	}
 };
 
 /**

--- a/lib/activity-accessory.js
+++ b/lib/activity-accessory.js
@@ -32,10 +32,10 @@ const ActivityStatus = {
 };
 module.exports.ActivityStatus = ActivityStatus;
 
-function ActivityAccessory(accessory, log, connection) {
+function ActivityAccessory(accessory, config, log, connection) {
 	this._onConnectionChanged = onConnectionChanged.bind(this);
 	this._onStateChanged = onStateChanged.bind(this);
-	HubAccessoryBase.call(this, accessory, connection, ActivityAccessory.typeKey, null, log);
+	HubAccessoryBase.call(this, accessory, connection, ActivityAccessory.typeKey, null, config, log);
 }
 util.inherits(ActivityAccessory, HubAccessoryBase);
 
@@ -193,7 +193,7 @@ ActivityAccessory.prototype._setActivityServiceOn = function(service, isOn, call
 		finish();
 	};
 
-	if ((isOn && !c.value) || (!isOn && c.value)) {
+	if (!this.config.skipIfSameState) {
 		return this.connection
 			.invokeAsync(function(client) {
 				self.log.debug("Switching to Activity: " + actId);
@@ -208,10 +208,26 @@ ActivityAccessory.prototype._setActivityServiceOn = function(service, isOn, call
 				self.log.debug("Switch Task Finished: " + actId);
 			});
 	} else {
-		var cb = callback;
-		callback = null;
-		c.removeListener('change', onChange);
-		if (cb) cb.apply(this, []);
+		if ((isOn && !c.value) || (!isOn && c.value)) {
+			return this.connection
+				.invokeAsync(function(client) {
+					self.log.debug("Switching to Activity: " + actId);
+					c.addListener('change', onChange);
+
+					var task = client.startActivity(actId);
+					self.log.debug("Switching Task Started: " + actId);
+					return task;
+				})
+				.asCallback(finish)
+				.finally(function(){
+					self.log.debug("Switch Task Finished: " + actId);
+				});
+		} else {
+			var cb = callback;
+			callback = null;
+			c.removeListener('change', onChange);
+			if (cb) cb.apply(this, []);
+		}
 	}
 };
 

--- a/lib/home-platform.js
+++ b/lib/home-platform.js
@@ -27,6 +27,7 @@ function HomePlatform(log, config, api) {
 	EventEmitter.call(this);
 
 	this.log = log;
+	this.config = config;
 
 	if (!config) {
 		log.warn("Ignoring Harmony Platform setup because it is not configured");
@@ -95,7 +96,7 @@ HomePlatform.prototype._finishInitializationAsync = function() {
 			if (!hubId) return;
 			var hub = self._hubs[hubId];
 			if (hub) return;
-			hub = new Hub(self.log);
+			hub = new Hub(self.config, self.log);
 			self._hubs[hubId] = hub;
 			self._hubIndex.push(hubId);
 			return self._refreshHubAccessoriesAsync(hubId, hub, false);
@@ -121,7 +122,7 @@ HomePlatform.prototype._handleDiscoveredHubAsync = function(hubInfo) {
 
 	var conn = new Connection(hubInfo, this.log, this._discover);
 	if (!hub) {
-		hub = new Hub(this.log, conn);
+		hub = new Hub(this.config, this.log, conn);
 		this._hubs[hubId] = hub;
 		this._hubIndex.push(hubId);
 	} else {

--- a/lib/hub-accessory-base.js
+++ b/lib/hub-accessory-base.js
@@ -18,7 +18,7 @@ module.exports = function(exportedTypes) {
 };
 module.exports.HubAccessoryBase = HubAccessoryBase;
 
-function HubAccessoryBase(accessory, connection, idKey, name, log) {
+function HubAccessoryBase(accessory, connection, idKey, name, config, log) {
 	var hubId, hubInfo;
 	if (connection) {
 		hubId = connection.hubId;
@@ -27,7 +27,7 @@ function HubAccessoryBase(accessory, connection, idKey, name, log) {
 		hubId = accessory.context.hubId;
 		hubInfo = accessory.context.hubInfo;
 	}
-	AccessoryBase.call(this, accessory, hubId + idKey, name || (hubInfo && hubInfo.friendlyName), log);
+	AccessoryBase.call(this, accessory, hubId + idKey, name || (hubInfo && hubInfo.friendlyName), config, log);
 	this._refreshConnection = refreshConnection.bind(this);
 	this.updateConnection(connection);
 }

--- a/lib/hub.js
+++ b/lib/hub.js
@@ -11,9 +11,10 @@ module.exports = function(exportedTypes) {
 };
 module.exports.Hub = Hub;
 
-function Hub(log, connection) {
+function Hub(config, log, connection) {
 	this.connection = connection;
 	this.log = log;
+	this.config = config;
 }
 
 Hub.prototype.updateConnection = function(connection) {
@@ -38,7 +39,7 @@ Hub.prototype.updateAccessoriesAsync = function(cachedAccessories) {
 		return acc.context.typeKey = ActivityAccessory.typeKey;
 	});
 	var activityAcc = _.find(this._accessories, function (a) { return a instanceof ActivityAccessory; });
-	if (!activityAcc) activityAcc = new ActivityAccessory(activityCachedAcc, this.log, conn);
+	if (!activityAcc) activityAcc = new ActivityAccessory(activityCachedAcc, this.config, this.log, conn);
 	var activityTask = activityAcc.initAsync().return(activityAcc);
 
 	return Promise.all([


### PR DESCRIPTION
On my local setup I have some devices that only have a "On/Off" button on their remotes.

Without this pull-request I have the problem that when I tell Siri to shutdown an activity which is not on it will power on devices instead of making sure that those are turned off.

This pullrequest ensures that only those changes for activity states are pushed to the hub which are actually changing the active state.