### PR TITLE
Pass options to Discover

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,38 +5,38 @@ Currently, this plugin displays Activities as switches.  This way you can turn o
 
 # Important 0.2.x changes
 
-In version 0.2.x, the plugin was drastically changed to allow much better connectivity handling, faster response, 
+In version 0.2.x, the plugin was drastically changed to allow much better connectivity handling, faster response,
 simplified integration, and true multi-hub support including auto adding newly discovered hubs.  
 
 As part of this, how your activities show up in HomeKit are very different.  Each hub will now properly show up as a single
-device in HomeKit instead of a device for each activity.  That device (accessory) for the hub will contain a switch for each activity 
-on that hub.  Just like before, turning on any activity on that hub will turn off all the others and just switching off the current activity 
-is equivalent to pressing the off button on the Harmony remote.  This will drastically clean up a HomeKit for most people and makes 
+device in HomeKit instead of a device for each activity.  That device (accessory) for the hub will contain a switch for each activity
+on that hub.  Just like before, turning on any activity on that hub will turn off all the others and just switching off the current activity
+is equivalent to pressing the off button on the Harmony remote.  This will drastically clean up a HomeKit for most people and makes
 it easier to determine which activity goes with which hub (if you have multiple).
 
-Since multi-hub support is built right into the platform (as of this release), users who used the work around of adding 
-the platform multiple times (with different IP address's specified) should just remove the IP addresses and go back to 
+Since multi-hub support is built right into the platform (as of this release), users who used the work around of adding
+the platform multiple times (with different IP address's specified) should just remove the IP addresses and go back to
 just one platform in your homebridge config.
 
-In order to fix many connectivity issues, give faster responses, and add auto discovery, the discovery/connection systems 
-wer greatly altered and integrated with one another.  Given this, plus the fact that multi-hub support is built right into 
-the platform, the ability to hard code the IP address of the hub in the config has been removed (for now).  Eventually, we 
-will likely reintegrate that feature in some way, but we will likely work on better, alternative solutions to unique cases 
-as hard coding IP addresses is not a good long term solution.  If you have one of these unique cases, feel free to write 
+In order to fix many connectivity issues, give faster responses, and add auto discovery, the discovery/connection systems
+wer greatly altered and integrated with one another.  Given this, plus the fact that multi-hub support is built right into
+the platform, the ability to hard code the IP address of the hub in the config has been removed (for now).  Eventually, we
+will likely reintegrate that feature in some way, but we will likely work on better, alternative solutions to unique cases
+as hard coding IP addresses is not a good long term solution.  If you have one of these unique cases, feel free to write
 up an issue in GitHub or (preferably) submit a pull request with a better solution to your case.
 
-**Warning**: when updating from 0.1.x to 0.2.x will remove any all HarmonyHub devices/activities/settings from HomeKit, replacing 
-them with the new setup.  This will _NOT_ effect your Harmony Hubs themselves. This will _NOT_ effect any other HomeKit/HomeBridge 
-devices/settings/etc.  The only real change is that any customizations you did to the old HarmonyHub HomeKit devices will be 
-reset; things like renaming an activity in HomeKit (which can effect Siri), adding an activity to a room/scene, etc will be reset. 
-All this means is that you will need to go back and redo anything customizations (reorganizing, renaming for Siri, etc) you did to 
+**Warning**: when updating from 0.1.x to 0.2.x will remove any all HarmonyHub devices/activities/settings from HomeKit, replacing
+them with the new setup.  This will _NOT_ effect your Harmony Hubs themselves. This will _NOT_ effect any other HomeKit/HomeBridge
+devices/settings/etc.  The only real change is that any customizations you did to the old HarmonyHub HomeKit devices will be
+reset; things like renaming an activity in HomeKit (which can effect Siri), adding an activity to a room/scene, etc will be reset.
+All this means is that you will need to go back and redo anything customizations (reorganizing, renaming for Siri, etc) you did to
 HarmonyHub devices in HomeKit.
 
 # Installation
 
 1. Install homebridge using: npm install -g homebridge
 2. Install this plugin using: npm install -g homebridge-harmonyhub
-3. Update your configuration file. See sample config.json snippet below. 
+3. Update your configuration file. See sample config.json snippet below.
 
 # Configuration
 
@@ -51,7 +51,19 @@ Configuration sample:
 	]
 ```
 
-Fields: 
+Fields:
 
 * "platform": Must always be "HarmonyHub" (required)
 * "name": Can be anything (used in logs)
+* "discoverOptions": an optional object of options to be passed to [harmonyhubjs-discover](https://github.com/swissmanu/harmonyhubjs-discover). On a system with multiple interfaces, or certain operating systems, you need to specify the broadcast address for the network the Harmony Hub is connected to. If your Hub is connected to the network 192.168.1.0/24, then you need to specify the address as 192.168.1.255:
+  ```json
+  "platforms": [
+		{
+			"platform": "HarmonyHub",
+			"name": "Harmony Hub",
+      "discoverOptions": {
+        "address": "192.168.1.255"
+      }
+		}
+	]  
+  ```

--- a/README.md
+++ b/README.md
@@ -5,38 +5,38 @@ Currently, this plugin displays Activities as switches.  This way you can turn o
 
 # Important 0.2.x changes
 
-In version 0.2.x, the plugin was drastically changed to allow much better connectivity handling, faster response,
+In version 0.2.x, the plugin was drastically changed to allow much better connectivity handling, faster response, 
 simplified integration, and true multi-hub support including auto adding newly discovered hubs.  
 
 As part of this, how your activities show up in HomeKit are very different.  Each hub will now properly show up as a single
-device in HomeKit instead of a device for each activity.  That device (accessory) for the hub will contain a switch for each activity
-on that hub.  Just like before, turning on any activity on that hub will turn off all the others and just switching off the current activity
-is equivalent to pressing the off button on the Harmony remote.  This will drastically clean up a HomeKit for most people and makes
+device in HomeKit instead of a device for each activity.  That device (accessory) for the hub will contain a switch for each activity 
+on that hub.  Just like before, turning on any activity on that hub will turn off all the others and just switching off the current activity 
+is equivalent to pressing the off button on the Harmony remote.  This will drastically clean up a HomeKit for most people and makes 
 it easier to determine which activity goes with which hub (if you have multiple).
 
-Since multi-hub support is built right into the platform (as of this release), users who used the work around of adding
-the platform multiple times (with different IP address's specified) should just remove the IP addresses and go back to
+Since multi-hub support is built right into the platform (as of this release), users who used the work around of adding 
+the platform multiple times (with different IP address's specified) should just remove the IP addresses and go back to 
 just one platform in your homebridge config.
 
-In order to fix many connectivity issues, give faster responses, and add auto discovery, the discovery/connection systems
-wer greatly altered and integrated with one another.  Given this, plus the fact that multi-hub support is built right into
-the platform, the ability to hard code the IP address of the hub in the config has been removed (for now).  Eventually, we
-will likely reintegrate that feature in some way, but we will likely work on better, alternative solutions to unique cases
-as hard coding IP addresses is not a good long term solution.  If you have one of these unique cases, feel free to write
+In order to fix many connectivity issues, give faster responses, and add auto discovery, the discovery/connection systems 
+wer greatly altered and integrated with one another.  Given this, plus the fact that multi-hub support is built right into 
+the platform, the ability to hard code the IP address of the hub in the config has been removed (for now).  Eventually, we 
+will likely reintegrate that feature in some way, but we will likely work on better, alternative solutions to unique cases 
+as hard coding IP addresses is not a good long term solution.  If you have one of these unique cases, feel free to write 
 up an issue in GitHub or (preferably) submit a pull request with a better solution to your case.
 
-**Warning**: when updating from 0.1.x to 0.2.x will remove any all HarmonyHub devices/activities/settings from HomeKit, replacing
-them with the new setup.  This will _NOT_ effect your Harmony Hubs themselves. This will _NOT_ effect any other HomeKit/HomeBridge
-devices/settings/etc.  The only real change is that any customizations you did to the old HarmonyHub HomeKit devices will be
-reset; things like renaming an activity in HomeKit (which can effect Siri), adding an activity to a room/scene, etc will be reset.
-All this means is that you will need to go back and redo anything customizations (reorganizing, renaming for Siri, etc) you did to
+**Warning**: when updating from 0.1.x to 0.2.x will remove any all HarmonyHub devices/activities/settings from HomeKit, replacing 
+them with the new setup.  This will _NOT_ effect your Harmony Hubs themselves. This will _NOT_ effect any other HomeKit/HomeBridge 
+devices/settings/etc.  The only real change is that any customizations you did to the old HarmonyHub HomeKit devices will be 
+reset; things like renaming an activity in HomeKit (which can effect Siri), adding an activity to a room/scene, etc will be reset. 
+All this means is that you will need to go back and redo anything customizations (reorganizing, renaming for Siri, etc) you did to 
 HarmonyHub devices in HomeKit.
 
 # Installation
 
 1. Install homebridge using: npm install -g homebridge
 2. Install this plugin using: npm install -g homebridge-harmonyhub
-3. Update your configuration file. See sample config.json snippet below.
+3. Update your configuration file. See sample config.json snippet below. 
 
 # Configuration
 
@@ -51,7 +51,7 @@ Configuration sample:
 	]
 ```
 
-Fields:
+Fields: 
 
 * "platform": Must always be "HarmonyHub" (required)
 * "name": Can be anything (used in logs)
@@ -61,9 +61,9 @@ Fields:
 		{
 			"platform": "HarmonyHub",
 			"name": "Harmony Hub",
-      "discoverOptions": {
-        "address": "192.168.1.255"
-      }
+			"discoverOptions": {
+				"address": "192.168.1.255"
+			}
 		}
-	]  
+	]
   ```

--- a/lib/home-platform.js
+++ b/lib/home-platform.js
@@ -54,7 +54,7 @@ function HomePlatform(log, config, api) {
 	self._isInitialized = false;
 	self._autoAddNewHubs = false;
 
-	self._discover = new Discover(61991);
+	self._discover = new Discover(61991, config.discoverOptions || {});
 
 	self._discover.on('update', function (hubs) {
 		self.log.debug('received update event from harmonyhubjs-discover. there are ' + hubs.length + ' hubs');
@@ -62,7 +62,7 @@ function HomePlatform(log, config, api) {
 		_.forEach(self._discoveredHubs, self._handleDiscoveredHubAsync.bind(self));
 		self.emit(Events.DiscoveredHubs, hubs);
 	});
-	
+
 	self._discover.start();
 
 	if (api) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bluebird": "^3.3.4",
     "debug": "^2.2.0",
     "harmonyhubjs-client": "^1.1.6",
-    "harmonyhubjs-discover": "^1.0.2",
+    "harmonyhubjs-discover": "^1.1.1",
     "inherits": "^2.0.1",
     "queue": "^3.1.0",
     "lodash": "^4.6"


### PR DESCRIPTION
This enables passing options to harmonyhubjs-discover's Discover
constructor.

This closes #105.

For systems with multiple interfaces, using the default broadcast
address of 255.255.255.255 will not give consistent results. Instead,
you need to pass the appropriate broadcast address for the network
you're addressing, like 192.168.1.255 for the network 192.168.1.0/24.

This PR requires swissmanu/harmonyhubjs-discover#8 to be merged and
released.

(Atom fixed the whitespace problems automatically. If you prefer, I can roll those back.)